### PR TITLE
Stroke weight accepts a decimal value rather than an integer one

### DIFF
--- a/lib/src/_core.dart
+++ b/lib/src/_core.dart
@@ -709,7 +709,7 @@ class Sketch {
   //------- End Shape/2D Primitives -----
 
   //----- Start Shape/Attributes ----
-  void strokeWeight(int newWeight) {
+  void strokeWeight(double newWeight) {
     if (newWeight < 0) {
       throw Exception('Stroke weight must be >= 0');
     }

--- a/test/shape/attributes.dart
+++ b/test/shape/attributes.dart
@@ -33,11 +33,10 @@ void main() {
       testWidgets('strokeWeight() invalid value', (tester) async {
         configureWindowForSpecTest(tester);
 
-        await expectLater(() {
-          final sketch = Sketch.simple();
-
-          sketch.strokeWeight(-1);
-        }, throwsA(isA<Exception>()));
+        await expectLater(
+          () => Sketch.simple()..strokeWeight(-1),
+          throwsA(isA<Exception>()),
+        );
       });
     });
   });


### PR DESCRIPTION
Following the [official documentation](https://processing.org/reference/) of Processing, the **[strokeWeight](https://processing.org/reference/strokeWeight_.html)** method should accepts a `float` value rather than an `integer` one.