### PR TITLE
Bugfix: check if mounted when _onSizeChanged in Processing widget (Resolves #82)

### DIFF
--- a/lib/src/_processing_widget.dart
+++ b/lib/src/_processing_widget.dart
@@ -121,7 +121,9 @@ class _ProcessingState extends State<Processing> with SingleTickerProviderStateM
 
   void _onSizeChanged() {
     WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
-      setState(() {});
+      if (mounted) {
+        setState(() {});
+      }
     });
   }
 


### PR DESCRIPTION
Bugfix: check if mounted when _onSizeChanged in Processing widget (Resolves #82)