### PR TITLE
Improved a couple test exception expectations (Resolves #30)

### DIFF
--- a/test/random/random_test.dart
+++ b/test/random/random_test.dart
@@ -1,5 +1,4 @@
 import 'dart:math';
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_processing/flutter_processing.dart';
@@ -28,9 +27,7 @@ void main() {
               expect(randomValue, 38.63148172405516);
 
               // with a lower bound that is larger than upper bound
-              expectLater(() {
-                s.random(10, 5);
-              }, throwsA(isA<Exception>()));
+              expect(() => s.random(10, 5), throwsException);
             },
           ),
         ),

--- a/test/shape/attributes_test.dart
+++ b/test/shape/attributes_test.dart
@@ -29,9 +29,9 @@ void main() {
       });
 
       testWidgets('strokeWeight() invalid value', (tester) async {
-        await expectLater(
+        expect(
           () => Sketch.simple()..strokeWeight(-1),
-          throwsA(isA<Exception>()),
+          throwsException,
         );
       });
     });


### PR DESCRIPTION
Improved a couple test exception expectations (Resolves #30)

The original ticket #30 was about exceptions in `pumpWidget`, but in the case in the ticket it's easier to verify the exception directly, without pumping a widget.