### PR TITLE
Update packages with breaking changes

### DIFF
--- a/example/lib/_demos_screen.dart
+++ b/example/lib/_demos_screen.dart
@@ -726,7 +726,7 @@ class _TakeScreenshotPromptState extends State<_TakeScreenshotPrompt> {
   String? _selectedPath;
 
   Future<void> _selectFilePath() async {
-    final filePath = await getSavePath(
+    final fileLocation = await getSaveLocation(
       acceptedTypeGroups: [
         XTypeGroup(
           extensions: [_imageFormat.extension],
@@ -739,7 +739,7 @@ class _TakeScreenshotPromptState extends State<_TakeScreenshotPrompt> {
 
     if (mounted) {
       setState(() {
-        _selectedPath = filePath;
+        _selectedPath = fileLocation?.path;
       });
     }
   }
@@ -827,9 +827,9 @@ class _GenerateGifPromptState extends State<_GenerateGifPrompt> {
   int _fps = 30;
 
   Future<void> _selectFilePath() async {
-    final filePath = await getSavePath(
+    final fileLocation = await getSaveLocation(
       acceptedTypeGroups: [
-        XTypeGroup(
+        const XTypeGroup(
           extensions: ['gif'],
           mimeTypes: ['image/gif'],
         ),
@@ -840,7 +840,7 @@ class _GenerateGifPromptState extends State<_GenerateGifPrompt> {
 
     if (mounted) {
       setState(() {
-        _selectedPath = filePath;
+        _selectedPath = fileLocation?.path;
       });
     }
   }
@@ -978,7 +978,7 @@ class _GenerateScreenshotFramesPromptState extends State<_GenerateScreenshotFram
   int _frameCount = 10;
 
   Future<void> _selectFilePath() async {
-    final filePath = await getSavePath(
+    final fileLocation = await getSaveLocation(
       acceptedTypeGroups: [
         XTypeGroup(
           extensions: [_imageFormat.extension],
@@ -991,12 +991,12 @@ class _GenerateScreenshotFramesPromptState extends State<_GenerateScreenshotFram
 
     if (mounted) {
       setState(() {
-        _selectedDirectory = filePath != null ? File(filePath).parent : null;
+        _selectedDirectory = fileLocation != null ? File(fileLocation.path).parent : null;
 
-        if (filePath != null) {
-          final fileName = FileName.fromFilePath(filePath);
+        if (fileLocation != null) {
+          final fileName = FileName.fromFilePath(fileLocation.path);
           _titleTemplate = fileName.name.endsWith('#') ? fileName.name : '${fileName.name}_###';
-          _templatePath = filePath;
+          _templatePath = fileLocation.path;
         } else {
           _titleTemplate = 'frame_###';
         }

--- a/example/lib/_processing_demo_sketch_display.dart
+++ b/example/lib/_processing_demo_sketch_display.dart
@@ -364,26 +364,26 @@ class ProcessingDemoState extends State<ProcessingDemo> with SingleTickerProvide
 
     // Retrieve the pixel data for the current sketch painting.
     final frameBytes = await image.toByteData();
-    final rawImageData = frameBytes!.buffer.asUint8List();
+    final rawImageBuffer = frameBytes!.buffer;
 
     // Convert the pixel data to the desired format.
     late List<int> formattedImageData;
     switch (imageFormat) {
       case ImageFileFormat.png:
         formattedImageData = imageFormats.encodePng(
-          imageFormats.Image.fromBytes(image.width, image.height, rawImageData),
+          imageFormats.Image.fromBytes(width: image.width, height: image.height, bytes: rawImageBuffer),
         );
         break;
       case ImageFileFormat.jpeg:
         formattedImageData = imageFormats.encodeJpg(
-          imageFormats.Image.fromBytes(image.width, image.height, rawImageData),
+          imageFormats.Image.fromBytes(width: image.width, height: image.height, bytes: rawImageBuffer),
         );
         break;
       case ImageFileFormat.tiff:
         throw UnimplementedError('Tiff images are not supported in save()');
       case ImageFileFormat.targa:
         formattedImageData = imageFormats.encodeTga(
-          imageFormats.Image.fromBytes(image.width, image.height, rawImageData),
+          imageFormats.Image.fromBytes(width: image.width, height: image.height, bytes: rawImageBuffer),
         );
         break;
     }

--- a/example/lib/demos/_hacking_demo.dart
+++ b/example/lib/demos/_hacking_demo.dart
@@ -42,7 +42,7 @@ class _HackingDemoState extends State<HackingDemo> {
         break;
     }
 
-    final filePath = await getSavePath(
+    final fileLocation = await getSaveLocation(
       acceptedTypeGroups: [
         XTypeGroup(
           extensions: [extension],
@@ -50,22 +50,22 @@ class _HackingDemoState extends State<HackingDemo> {
         ),
       ],
     );
-    if (filePath == null) {
+    if (fileLocation == null) {
       print('User cancelled the file selection');
       return;
     }
 
-    _fileToSaveImage = File(filePath);
+    _fileToSaveImage = File(fileLocation.path);
   }
 
   Future<void> _saveImageFrame() async {
-    final filePath = await getSavePath();
-    if (filePath == null) {
+    final fileLocation = await getSaveLocation();
+    if (fileLocation == null) {
       print('User cancelled the file selection');
       return;
     }
 
-    _dirToSaveFrames = File(filePath).parent;
+    _dirToSaveFrames = File(fileLocation.path).parent;
     _remainingFrames = 10;
   }
 

--- a/example/lib/io/gif.dart
+++ b/example/lib/io/gif.dart
@@ -40,7 +40,7 @@ class GifGenerator {
 
     await sketch.loadPixels();
 
-    final gifFrame = gif.Image.fromBytes(sketch.width, sketch.height, sketch.pixels!.buffer.asUint8List());
+    final gifFrame = gif.Image.fromBytes(width: sketch.width, height: sketch.height, bytes: sketch.pixels!.buffer);
     final timeInHundredths = (_gifFrameRateFps.inMilliseconds / 10).round();
     _gifEncoder.addFrame(gifFrame, duration: timeInHundredths);
     _addedFrameCount += 1;
@@ -68,7 +68,7 @@ class GifGenerator {
     }
 
     final frameBytes = await frame.toByteData();
-    final gifFrame = gif.Image.fromBytes(frame.width, frame.height, frameBytes!.buffer.asUint8List());
+    final gifFrame = gif.Image.fromBytes(width: frame.width, height: frame.height, bytes: frameBytes!.buffer);
     _frames.add(gifFrame);
     // final timeInHundredths = (_gifFrameRateFps.inMilliseconds / 10).round();
     // _gifEncoder.addFrame(gifFrame, duration: timeInHundredths);

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: ae3e2b5dcfd7262920f3a36df8f04a9f798bafe395d7dc6cf2a7178ae8aba792
+      sha256: "22600aa1e926be775fa5fe7e6894e7fb3df9efda8891c73f70fb3262399a432d"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.6"
+    version: "3.4.10"
   async:
     dependency: transitive
     description:
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   cross_file:
     dependency: transitive
     description:
@@ -69,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: cf75650c66c0316274e21d7c43d3dea246273af5955bd94e8184837cd577575c
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -197,15 +205,23 @@ packages:
     dependency: "direct main"
     description:
       name: image
-      sha256: "3e5c9ef82c0af7823be4cb5294a829a6e0548a6f6b4e261e6386509a9e03bcab"
+      sha256: "4c68bfd5ae83e700b5204c1e74451e7bf3cf750e6843c6e158289cf56bda018e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "4.1.7"
   integration_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.1"
   lints:
     dependency: transitive
     description:
@@ -266,10 +282,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "85e8f8b118afcccf948a9844d199e56260117400bd9b9982d87bf1d62ebc1690"
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "6.0.2"
   platform:
     dependency: transitive
     description:
@@ -286,6 +302,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "43ac87de6e10afabc85c445745a7b799e04de84cebaa4fd7bf55a5e1e9604d29"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.7.4"
   popover:
     dependency: "direct main"
     description:
@@ -407,10 +431,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "9d2cf96b38e3f523fb78f0102d1d4483f817f3c3a6d81f46bf1b7a430ae8d561"
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "6.5.0"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.2.0 <4.0.0"
   flutter: ">=2.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   cross_file:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: fast_noise
-      sha256: "271031cebf1602fc064472970e658fa7ff2f3b55a979bb430337b715bd55690b"
+      sha256: "2aa7bbde5599d2b6769750ee23536ec8a0096606fc9d10d29a3855e80715e1c6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   file:
     dependency: transitive
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "6a2ef17156f4dc49684f9d99aaf4a93aba8ac49f5eac861755f5730ddf6e2e4e"
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -234,10 +234,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   path:
     dependency: "direct main"
     description:
@@ -274,10 +274,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      sha256: ae68c7bfcd7383af3629daafb32fb4e8681c7154428da4febcff06200585f102
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.2"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -319,18 +319,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -359,10 +359,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
@@ -383,18 +383,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: c620a6f783fa22436da68e42db7ebbf18b8c44b9a46ab911f666ff09ffd9153f
+      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
       url: "https://pub.dev"
     source: hosted
-    version: "11.7.1"
+    version: "11.10.0"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
   webdriver:
     dependency: transitive
     description:
@@ -412,5 +412,5 @@ packages:
     source: hosted
     version: "5.1.1"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=2.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -109,34 +109,66 @@ packages:
     dependency: "direct main"
     description:
       name: file_selector
-      sha256: "58d8182e75b848dbe865bcef13e7fea5ac51842ef6e6f1364ca5219f95b14bbf"
+      sha256: "5019692b593455127794d5718304ff1ae15447dea286cdda9f0db2a796a1b828"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.2"
+    version: "1.0.3"
+  file_selector_android:
+    dependency: transitive
+    description:
+      name: file_selector_android
+      sha256: "1cd66575f063b689e041aec836905ba7be18d76c9f0634d0d75daec825f67095"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0+7"
+  file_selector_ios:
+    dependency: transitive
+    description:
+      name: file_selector_ios
+      sha256: b015154e6d9fddbc4d08916794df170b44531798c8dd709a026df162d07ad81d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1+8"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "045d372bf19b02aeb69cacf8b4009555fb5f6f0b7ad8016e5f46dd1387ddd492"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.2+1"
   file_selector_macos:
     dependency: "direct main"
     description:
       name: file_selector_macos
-      sha256: "6d5a9bed69ec5ff0c1de1e282a1b5a008a83a9f0cf11ef1fc229f90e81b9a720"
+      sha256: b15c3da8bd4908b9918111fa486903f5808e388b8d1c559949f584725a6594d6
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.4"
+    version: "0.9.3+3"
   file_selector_platform_interface:
     dependency: transitive
     description:
       name: file_selector_platform_interface
-      sha256: "1d1d4ac5da43bcc2596e4e4d2522dc28f00b2c2e3ea293f0dbcc6f5d368b9afa"
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.6.2"
   file_selector_web:
     dependency: transitive
     description:
       name: file_selector_web
-      sha256: f56327c21cdc77bd1ec281c1ad081138daa9073a9a9339389831db5287e34124
+      sha256: c0f025d460de3301b7bbbf837fc8d0759df85f182c635f1dd94934b4cdc92352
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.1"
+    version: "0.9.3"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: d3547240c20cabf205c7c7f01a50ecdbc413755814d6677f3cb366f04abcead0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+1"
   fixnum:
     dependency: transitive
     description:
@@ -298,10 +330,10 @@ packages:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: "5aadc2af7cd403ad0b95ef654c3e628517f4cae9682b4229a66caf9df71844d2"
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.8"
   pointycastle:
     dependency: transitive
     description:
@@ -437,4 +469,4 @@ packages:
     version: "6.5.0"
 sdks:
   dart: ">=3.2.0 <4.0.0"
-  flutter: ">=2.0.0"
+  flutter: ">=3.16.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   flutter_processing:
     path: ../
 
-  file_selector: ^0.8.2
-  file_selector_macos: ^0.0.4
+  file_selector: ^1.0.3
+  file_selector_macos: ^0.9.3+3
   image: ^4.1.7
   path: ^1.8.0
   patterns_canvas: ^0.3.5

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
   file_selector: ^0.8.2
   file_selector_macos: ^0.0.4
-  image: ^3.0.2
+  image: ^4.1.7
   path: ^1.8.0
   patterns_canvas: ^0.3.5
   popover: ^0.2.6+2

--- a/lib/src/math/_random.dart
+++ b/lib/src/math/_random.dart
@@ -27,7 +27,7 @@ mixin SketchMathRandom {
   int _perlinNoiseSeed = 1337;
   int _perlinNoiseOctaves = 4;
   double _perlinNoiseFalloff = 0.5;
-  PerlinNoise? _perlinNoise;
+  PerlinFractalNoise? _perlinNoise;
 
   /// Sets the seed value for all [noise()] invocations to the given
   /// [seed].
@@ -68,11 +68,11 @@ mixin SketchMathRandom {
       _initializePerlinNoise();
     }
 
-    return _perlinNoise!.getPerlin3(x, y, z);
+    return _perlinNoise!.getNoise3(x, y, z);
   }
 
   void _initializePerlinNoise() {
-    _perlinNoise = PerlinNoise(
+    _perlinNoise = PerlinFractalNoise(
       seed: _perlinNoiseSeed,
       octaves: _perlinNoiseOctaves,
       gain: _perlinNoiseFalloff,

--- a/lib/src/output/_image.dart
+++ b/lib/src/output/_image.dart
@@ -120,19 +120,19 @@ Future<void> saveBytesToFile({
   switch (imageFormat) {
     case ImageFileFormat.png:
       formattedImageData = imageFormats.encodePng(
-        imageFormats.Image.fromBytes(width, height, imageData),
+        imageFormats.Image.fromBytes(width: width, height: height, bytes: imageData.buffer),
       );
       break;
     case ImageFileFormat.jpeg:
       formattedImageData = imageFormats.encodeJpg(
-        imageFormats.Image.fromBytes(width, height, imageData),
+        imageFormats.Image.fromBytes(width: width, height: height, bytes: imageData.buffer),
       );
       break;
     case ImageFileFormat.tiff:
       throw UnimplementedError('Tiff images are not supported in save()');
     case ImageFileFormat.targa:
       formattedImageData = imageFormats.encodeTga(
-        imageFormats.Image.fromBytes(width, height, imageData),
+        imageFormats.Image.fromBytes(width: width, height: height, bytes: imageData.buffer),
       );
       break;
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: a92e39b291073bb840a72cf43d96d2a63c74e9a485d227833e8ea0054d16ad16
+      sha256: "22600aa1e926be775fa5fe7e6894e7fb3df9efda8891c73f70fb3262399a432d"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.4.10"
   async:
     dependency: transitive
     description:
@@ -49,14 +49,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: cf75650c66c0316274e21d7c43d3dea246273af5955bd94e8184837cd577575c
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -111,10 +119,18 @@ packages:
     dependency: "direct main"
     description:
       name: image
-      sha256: "3e5c9ef82c0af7823be4cb5294a829a6e0548a6f6b4e261e6386509a9e03bcab"
+      sha256: "4c68bfd5ae83e700b5204c1e74451e7bf3cf750e6843c6e158289cf56bda018e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "4.1.7"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.1"
   lints:
     dependency: transitive
     description:
@@ -159,10 +175,18 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "85e8f8b118afcccf948a9844d199e56260117400bd9b9982d87bf1d62ebc1690"
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "6.0.2"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "43ac87de6e10afabc85c445745a7b799e04de84cebaa4fd7bf55a5e1e9604d29"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.7.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -244,10 +268,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "30498604ab00fc50286f8aaf7e077c496550b16ed2f325c14152244882314f03"
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.2"
+    version: "6.5.0"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.2.0 <4.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -69,18 +69,18 @@ packages:
     dependency: "direct main"
     description:
       name: fast_noise
-      sha256: "271031cebf1602fc064472970e658fa7ff2f3b55a979bb430337b715bd55690b"
+      sha256: "2aa7bbde5599d2b6769750ee23536ec8a0096606fc9d10d29a3855e80715e1c6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "6a2ef17156f4dc49684f9d99aaf4a93aba8ac49f5eac861755f5730ddf6e2e4e"
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -143,10 +143,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   path:
     dependency: "direct main"
     description:
@@ -180,18 +180,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -212,10 +212,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
@@ -236,10 +236,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
   xml:
     dependency: transitive
     description:
@@ -249,5 +249,5 @@ packages:
     source: hosted
     version: "5.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  fast_noise: ^1.0.1
+  fast_noise: ^2.0.0
   image: ^3.0.2
   path: ^1.8.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   fast_noise: ^2.0.0
-  image: ^3.0.2
+  image: ^4.1.7
   path: ^1.8.0
 
 dev_dependencies:


### PR DESCRIPTION
* Update packages that had breaking changes:
   * The `file_selector` package replaces `getSavePath` with `getSaveLocation`.
   * The `image` package's `fromBytes` method uses named parameters and takes a `ByteBuffer` instead of `Uint8List`.
   * The `fast_noise` package now has a separate `PerlinFractalNoise` class for perlin noise fractal implementation and the previous `PerlinNoise` is the base noise object that only accepts frequency (see this [PR description](https://github.com/bluefireteam/fast_noise/pull/5) for more details)
