### PR TITLE
Use test view API

### DIFF
--- a/test/complex_shapes_test.dart
+++ b/test/complex_shapes_test.dart
@@ -7,9 +7,9 @@ import 'package:golden_toolkit/golden_toolkit.dart';
 void main() {
   group('Complex shapes', () {
     testGoldens('stars', (tester) async {
-      tester.binding.window
-        ..physicalSizeTestValue = Size(640, 360)
-        ..devicePixelRatioTestValue = 1.0;
+      tester.view
+        ..physicalSize = Size(640, 360)
+        ..devicePixelRatio = 1.0;
 
       await tester.pumpWidget(
         Processing(
@@ -19,13 +19,13 @@ void main() {
 
       await screenMatchesGolden(tester, 'complex-shapes_stars');
 
-      tester.binding.window.clearAllTestValues();
+      tester.platformDispatcher.clearAllTestValues();
     });
 
     testGoldens('triangle strip circle', (tester) async {
-      tester.binding.window
-        ..physicalSizeTestValue = Size(640, 360)
-        ..devicePixelRatioTestValue = 1.0;
+      tester.view
+        ..physicalSize = Size(640, 360)
+        ..devicePixelRatio = 1.0;
 
       await tester.pumpWidget(
         Processing(
@@ -35,7 +35,7 @@ void main() {
 
       await screenMatchesGolden(tester, 'complex-shapes_triangle-strip-circle');
 
-      tester.binding.window.clearAllTestValues();
+      tester.platformDispatcher.clearAllTestValues();
     });
   });
 }

--- a/test/environment/environment_test.dart
+++ b/test/environment/environment_test.dart
@@ -48,7 +48,7 @@ void main() {
     processingLegacySpecTest('size()', (tester) async {
       // Expand the canvas to leave enough space for
       // a larger Processing sketch.
-      tester.binding.window.physicalSizeTestValue = Size(250, 250);
+      tester.view.physicalSize = Size(250, 250);
 
       await tester.pumpWidget(
         Processing(

--- a/test/test_infra.dart
+++ b/test/test_infra.dart
@@ -14,13 +14,13 @@ import 'package:golden_toolkit/golden_toolkit.dart';
 /// from before Aug, 2021.
 void processingSpecTest(String description, Future<void> Function(WidgetTester) test) {
   testGoldens(description, (tester) async {
-    tester.binding.window
-      ..physicalSizeTestValue = Size(400, 400)
-      ..devicePixelRatioTestValue = 1.0;
+    tester.view
+      ..physicalSize = Size(400, 400)
+      ..devicePixelRatio = 1.0;
 
     await test(tester);
 
-    tester.binding.window.clearAllTestValues();
+    tester.platformDispatcher.clearAllTestValues();
   });
 }
 
@@ -34,13 +34,13 @@ void processingLegacySpecTest(String description, Future<void> Function(WidgetTe
   testGoldens(description, (tester) async {
     // All the legacy Processing reference examples (before Aug 2021)
     // were 100x100 px.
-    tester.binding.window
-      ..physicalSizeTestValue = Size(100, 100)
-      ..devicePixelRatioTestValue = 1.0;
+    tester.view
+      ..physicalSize = const Size(100, 100)
+      ..devicePixelRatio = 1.0;
 
     await test(tester);
 
-    tester.binding.window.clearAllTestValues();
+    tester.platformDispatcher.clearAllTestValues();
   });
 }
 


### PR DESCRIPTION
Replaces deprecated `tester.binding.window` usages in tests with the new test view API